### PR TITLE
auto start nginx and php after starting dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -48,5 +48,6 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "sudo chmod a+x \"$(pwd)\" && sudo rm -rf /var/www/html && sudo ln -s \"$(pwd)\" /var/www/html"
 	// Set `remoteUser` to `root` to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+	"remoteUser": "vscode",
+	"postStartCommand": "nohup bash -c 'start &' > /dev/null 2>&1"
 }


### PR DESCRIPTION
Simply use the dev container's `postStartCommand` configuration to automatically start the nginx and php services after opening a project in the vscode dev container, avoiding the need to manually execute commands to start them each time we reopen the workspace.

For more details:
- It will wrap `postStartCommand` into executing `/bin/sh -c ${postStartCommand}`, so simply filling `start` or `start &` is not work, and the process may exit early before both nginx and php are started.
- The `start` script itself does not produce any output, we can feel ease to redirect its stdout to null, avoiding the creation of `nohup.out`.
- Though the `postStartCommand` can be passed with an array of commands, for scalability, I keep the `start` script to execute all necessary tasks.