### PR TITLE
fix: restore passkey registration options

### DIFF
--- a/packages/hikarilan/flarum-passkey-login/UPSTREAM.md
+++ b/packages/hikarilan/flarum-passkey-login/UPSTREAM.md
@@ -5,14 +5,14 @@
 | 项 | 值 |
 |---|---|
 | Fork repository | `https://github.com/0xffff-one/flarum-passkey-login` |
-| Fixed fork commit | `d7e568bdb55467c87e332f0a2934e46a9f1a3b96`（`fix: upgrade WebAuthn dependency to 5.3.5`） |
+| Fixed fork commit | `19fe3bb`（`fix: restore passkey registration options`） |
 | Upstream repository | `https://github.com/shaokeyibb/flarum-passkey-login`（同 commit `132ccc0`） |
 | License | Apache-2.0，见 `LICENSE.md` |
-| Snapshot base | fork `d7e568b` 的 55 个受控文件；本地唯一额外文件为本 `UPSTREAM.md` |
+| Snapshot base | fork `19fe3bb` 的 56 个受控文件；本地唯一额外文件为本 `UPSTREAM.md` |
 
 ## 内容
 
-本目录是 fork `d7e568b` 的完整 source snapshot，保留 package name `hikarilan/flarum-passkey-login`、PHP namespace、settings key、DB table、routes 与 JS public API。不依赖 vendor 作为 source。`js/dist` 为已发布的 bundle，原样保留。
+本目录是 fork `19fe3bb` 的完整 source snapshot，保留 package name `hikarilan/flarum-passkey-login`、PHP namespace、settings key、DB table、routes 与 JS public API。不依赖 vendor 作为 source。`js/dist` 为已发布的 bundle，原样保留。
 
 ## 同步方式
 
@@ -25,11 +25,11 @@
 计算命令（在仓库根执行；摘要覆盖 55 个受控文件，排除本 `UPSTREAM.md` 与 Composer 安装元数据）：
 
 ```sh
-( cd packages/hikarilan/flarum-passkey-login && find . -type f ! -name UPSTREAM.md ! -name composer.lock ! -name composer.phar | LC_ALL=C sort | sed -E 's#^\./(.*)$#\1#' | xargs -d '\n' sha256sum ) | sha256sum
+( cd packages/hikarilan/flarum-passkey-login && find . -type f ! -path './.git/*' ! -path './vendor/*' ! -path './node_modules/*' ! -name UPSTREAM.md ! -name composer.lock ! -name composer.phar | LC_ALL=C sort | sed -E 's#^\./(.*)$#\1#' | xargs -d '\n' sha256sum ) | sha256sum
 ```
 
-当前 digest（fork `d7e568b` 全量受控文件，与本地 55 个受控文件一致；本地唯一额外文件为本 `UPSTREAM.md`）：
+当前 digest（fork `19fe3bb` 全量受控文件，与本地 56 个受控文件一致；本地唯一额外文件为本 `UPSTREAM.md`）：
 
 ```text
-d4af575690ef522abc8d52726f47a9069efa60772c5a5d123ce14893378a8f56
+2adb8e5b30ded685aa89aee6aeec0e6ffbe40e2fcef56ea7bd2d00c56ef89da4
 ```

--- a/packages/hikarilan/flarum-passkey-login/src/Controllers/PasskeyRegistrationOptionsController.php
+++ b/packages/hikarilan/flarum-passkey-login/src/Controllers/PasskeyRegistrationOptionsController.php
@@ -55,7 +55,6 @@ class PasskeyRegistrationOptionsController implements RequestHandlerInterface
         $authenticatorSelectionCriteria = AuthenticatorSelectionCriteria::create(
             userVerification: AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED,
             residentKey: AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED,
-            requireResidentKey: null
         );
 
         $publicKeyCredentialCreationOptions = PublicKeyCredentialCreationOptions::create(

--- a/packages/hikarilan/flarum-passkey-login/tests/registration-options-compatibility.php
+++ b/packages/hikarilan/flarum-passkey-login/tests/registration-options-compatibility.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Webauthn\AuthenticatorSelectionCriteria;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialParameters;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+if ($argc !== 2) {
+    throw new InvalidArgumentException('Usage: php tests/registration-options-compatibility.php /path/to/vendor/autoload.php');
+}
+
+require $argv[1];
+
+$controllerSource = file_get_contents(dirname(__DIR__) . '/src/Controllers/PasskeyRegistrationOptionsController.php');
+is_string($controllerSource) || throw new RuntimeException('Unable to read the registration options controller.');
+
+str_contains($controllerSource, 'requireResidentKey:')
+    && throw new RuntimeException('WebAuthn 5 does not accept requireResidentKey as a named factory argument.');
+
+$selection = AuthenticatorSelectionCriteria::create(
+    userVerification: AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED,
+    residentKey: AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_REQUIRED,
+);
+
+$selection->requireResidentKey === true
+    || throw new RuntimeException('WebAuthn 5 must derive requireResidentKey from residentKey.');
+
+$options = PublicKeyCredentialCreationOptions::create(
+    PublicKeyCredentialRpEntity::create('0xFFFF', '0xffff.one'),
+    PublicKeyCredentialUserEntity::create('0x0001', '1', '0x0001'),
+    random_bytes(16),
+    [
+        PublicKeyCredentialParameters::createPk(-7),
+        PublicKeyCredentialParameters::createPk(-257),
+    ],
+    authenticatorSelection: $selection,
+    timeout: 60_000,
+);
+
+count($options->pubKeyCredParams) === 2
+    || throw new RuntimeException('Registration options must retain ES256 and RS256 algorithms.');
+
+echo "Registration options compatibility passed.\n";


### PR DESCRIPTION
Outcome: restore passkey creation after the WebAuthn 5.3.5 upgrade.

Behavior change: consume the corrected controlled passkey extension snapshot, removing the obsolete WebAuthn factory argument.

Preserved: no Composer lock drift, schema, route, settings, or frontend-bundle changes.

Risk boundary: only authenticated registration-options generation changes; existing passkey assertion/login flow is untouched.

Verification: focused registration-options and legacy-credential regressions in the final image; Composer validation; full local Docker build. The only platform warning remains the pre-existing Firebase PHP 8.5 declaration limit.